### PR TITLE
CO-9898 Retry search call in case of 400 response

### DIFF
--- a/resources/manage.rb
+++ b/resources/manage.rb
@@ -198,14 +198,14 @@ action_class do
         retries ||= 0
         if retries < max_retries
           retries += 1
-          Chef::Log.error("Got 400 bad request on search - Retrying #{retries}/#{max_retries}")
+          Chef::Log.error("Got 400 bad request on '#{data_bag}' search with query '#{query}' - Retrying #{retries}/#{max_retries}")
           retry
         else
-          Chef::Log.error(e.message)
+          Chef::Log.error("Got 400 bad request on '#{data_bag}' search with query '#{query}' after #{max_retries} retries. Error - #{e.message}")
           raise e
         end
       else
-        Chef::Log.error(e.message)
+        Chef::Log.error("Got http #{e.response.code} on '#{data_bag}' search with query '#{query}'. Error - #{e.message}")
         raise e
       end
     end  

--- a/resources/manage.rb
+++ b/resources/manage.rb
@@ -41,7 +41,7 @@ action :create do
               retries ||= 0
               if retries < max_retries
                 retries += 1
-                Chef::Log.error("Got 400 bad request on search - Retrying #{retries/max_retries}")
+                Chef::Log.error("Got 400 bad request on search - Retrying #{retries}/#{max_retries}")
                 retry
               else
                 Chef::Log.error(e.message)
@@ -192,7 +192,7 @@ action :remove do
               retries ||= 0
               if retries < max_retries
                 retries += 1
-                Chef::Log.error("Got 400 bad request on search - Retrying #{retries/max_retries}")
+                Chef::Log.error("Got 400 bad request on search - Retrying #{retries}/#{max_retries}")
                 retry
               else
                 Chef::Log.error(e.message)


### PR DESCRIPTION
## JIRA


* [Main JIRA ticket](https://coupadev.atlassian.net/browse/CO-9898)

## Code reviewers

- [x] @pallav-jakhotiya 
- [ ] @alokdnb 
- [ ] @charchitcoupa 
- [x] @Ramesh7 
- [ ] @kumartushar  

## Summary of issue
Chef server search query giving 400 bad request error on malformed search URL string.

## Summary of change
- Able to reproduce the issue when ran search query with 1000 threads.
- Not able to find root cause as why chef-client is forming such bad search url intermittently.
- Chef client's http client does have retry mechanism, but it does retry on same URL, so not useful in this case.
- Have added retry mechanism on search call itself if it gets 400 response code,  max retry count is set to `Chef::Config[:http_retry_count]` which is 5 by default.


## Testing approach
- [x] Manual test
   More on ticket.


## Generated Reviewers

### Ops Cookbook Review (ops_cookbook)

- [x] @pallav-jakhotiya
  - This rule is always triggered
