### PR TITLE
CE-12754 CE-12655 [5.0] New action to remove users with create action

### DIFF
--- a/resources/manage.rb
+++ b/resources/manage.rb
@@ -28,6 +28,7 @@ property :group_name, String, name_property: true
 property :group_id, Integer
 property :cookbook, String, default: 'users'
 property :manage_nfs_home_dirs, [true, false], default: true
+property :skip_users, Array, default: []
 
 action :create do
   users_groups = {}
@@ -191,6 +192,20 @@ action :remove do
       action :remove
       manage_home true
       force rm_user['force'] ||= false
+    end
+  end
+end
+
+action :remove_if_created do
+  users = search_users(new_resource.data_bag, "groups:#{new_resource.search_group} AND NOT action:remove")
+  users.each do |rm_user|
+    rm_user['username'] ||= rm_user['id']
+    user rm_user['username'] do
+      action :remove
+      manage_home true
+      force rm_user['force'] ||= false
+      not_if { is_user_session_active?(rm_user['username']) }
+      not_if { new_resource.skip_users.include?(rm_user['username']) }
     end
   end
 end

--- a/resources/manage.rb
+++ b/resources/manage.rb
@@ -28,7 +28,7 @@ property :group_name, String, name_property: true
 property :group_id, Integer
 property :cookbook, String, default: 'users'
 property :manage_nfs_home_dirs, [true, false], default: true
-property :skip_users, Array, default: []
+property :keep_users, Array, default: []
 
 action :create do
   users_groups = {}
@@ -205,7 +205,7 @@ action :remove_if_created do
       manage_home true
       force rm_user['force'] ||= false
       not_if { is_user_session_active?(rm_user['username']) }
-      not_if { new_resource.skip_users.include?(rm_user['username']) }
+      not_if { new_resource.keep_users.include?(rm_user['username']) }
     end
   end
 end


### PR DESCRIPTION
Propagation of https://github.com/coupa-ops/users/pull/9 to 5.0

## JIRA

* [Main JIRA ticket](https://coupadev.atlassian.net/browse/CE-12764)

## Summary of issue

- Need a new action to remove users if they are created.

## Summary of change
- Added a new action named `remove_if_created`, which will remove all users if they have create action or does not have remove action in their Users databag
- If user session is live, then that user will be skipped from removal
- Added provision to skip users from deletion based on given array

## Testing approach

- [x] Serverspec test (mandatory)
- [x] Manual test
- [ ] No test (please specify why)
